### PR TITLE
improve the Queue class

### DIFF
--- a/connections.cpp
+++ b/connections.cpp
@@ -84,7 +84,7 @@ void Connections::request(int fd) {
 void Connections::worker() {
     while(this->running.load()) {
         int fd;
-        if(this->queue.pop(&fd)!=0)
+        if(!this->queue.pop(&fd))
             break;
 
         int error;


### PR DESCRIPTION
Hi, I stumble upon your code and find a memory leak on your queue implementation. Indeed, the `queue_node` is not freed after the pop operation.

I also change a little bit the behavior of `stopqueue` method. Now, this method only puts the queue in a closing state thus writers cannot push new elements, but the readers can continue pop elements.
The complete deallocation of the queue will be executed in the deconstructor.

Other improvements:
 - substitute `NULL` with `nullptr`
- use the wait with predicates to manage spurious wake-up on the conditional variable
- use bool instead of int

Let me know if you need somethings else :)
